### PR TITLE
Force MapListContainers' selection listener to update once when choosing a same map.

### DIFF
--- a/core/src/com/etheller/warsmash/viewer5/handlers/w3x/ui/MenuUI.java
+++ b/core/src/com/etheller/warsmash/viewer5/handlers/w3x/ui/MenuUI.java
@@ -1095,10 +1095,16 @@ public class MenuUI {
 				"MapListContainer", this.dataSource, profileListText.getFrameFont());
 		mapListContainer.addSelectionListener(new ListBoxSelelectionListener() {
 			War3Map lastMapListMap;
+			String prevSelectedItem = "";
 
 			@Override
 			public void onSelectionChanged(final int newSelectedIndex, final String newSelectedItem) {
 				if (newSelectedItem != null) {
+					if (newSelectedItem.compareTo(prevSelectedItem) == 0) {
+						return;
+					}
+					prevSelectedItem = newSelectedItem;
+
 					try {
 						final War3Map map = War3MapViewer.beginLoadingMap(MenuUI.this.dataSource, newSelectedItem);
 						if (this.lastMapListMap != null) {

--- a/core/src/com/etheller/warsmash/viewer5/handlers/w3x/ui/menu/BattleNetUI.java
+++ b/core/src/com/etheller/warsmash/viewer5/handlers/w3x/ui/menu/BattleNetUI.java
@@ -501,12 +501,19 @@ public class BattleNetUI {
 		final MapListContainer mapListContainer = new MapListContainer(this.rootFrame, this.uiViewport,
 				"MapListContainer", dataSource, mapListLabel.getFrameFont());
 		mapListContainer.addSelectionListener(new ListBoxSelelectionListener() {
+			String prevSelectedItem = "";
 
 			@Override
 			public void onSelectionChanged(final int newSelectedIndex, final String newSelectedItem) {
-				BattleNetUI.this.customCreateCurrentMapConfig = null;
-				BattleNetUI.this.customCreateCurrentMapInfo = null;
 				if (newSelectedItem != null) {
+					if (newSelectedItem.compareTo(prevSelectedItem) == 0) {
+						return;
+					}
+					prevSelectedItem = newSelectedItem;
+
+					BattleNetUI.this.customCreateCurrentMapConfig = null;
+					BattleNetUI.this.customCreateCurrentMapInfo = null;
+
 					BattleNetUI.this.customCreatePanelCurrentSelectedMapPath = newSelectedItem;
 
 					try {


### PR DESCRIPTION
I think it make sense for MapListContainers to only update the selected map once if a different map is being selected otherwise it's selection listener would be interrupted shortly. This would benefit both memory and performance to avoid constantly allocating new mapInfo and mapConfig pinpointed to the same map; and to avoid a sudden lag spike from spam-clicking a large map.