### PR TITLE
Bugfix to #30

### DIFF
--- a/core/src/com/etheller/warsmash/viewer5/handlers/w3x/simulation/abilities/harvest/CAbilityHarvest.java
+++ b/core/src/com/etheller/warsmash/viewer5/handlers/w3x/simulation/abilities/harvest/CAbilityHarvest.java
@@ -125,6 +125,10 @@ public class CAbilityHarvest extends AbstractGenericSingleIconActiveAbility {
 			final CUnit targetUnit = (CUnit) target;
 			for (final CAbility ability : targetUnit.getAbilities()) {
 				if (ability instanceof CAbilityGoldMinable) {
+					if(this.goldCapacity <= 0){
+						receiver.mustTargetResources();
+						return;
+					}
 					receiver.targetOk(target);
 					return;
 				}
@@ -140,6 +144,10 @@ public class CAbilityHarvest extends AbstractGenericSingleIconActiveAbility {
 		}
 		else if (target instanceof CDestructable) {
 			if (target.canBeTargetedBy(game, unit, this.treeAttack.getTargetsAllowed())) {
+				if(this.lumberCapacity <= 0){
+					receiver.mustTargetResources();
+					return;
+				}
 				receiver.targetOk(target);
 			}
 			else {


### PR DESCRIPTION
Fixed the bug by stopping the harvesters (i.e ghouls) from mining the gold mine if the gold capacity of their harvest ability is 0. 

This would also stop harvesters from harvesting trees if the lumber capacity is also 0.
[Explanation](https://github.com/Retera/WarsmashModEngine/issues/30#issuecomment-1500800162)