### PR TITLE
Add null check for Warchasers map

### DIFF
--- a/core/src/com/etheller/warsmash/parsers/jass/Jass2.java
+++ b/core/src/com/etheller/warsmash/parsers/jass/Jass2.java
@@ -2645,7 +2645,10 @@ public class Jass2 {
 
 					final CItem newItem = CommonEnvironment.this.simulation.createItem(new War3ID(rawcode), unit.getX(),
 							unit.getY());
-					unit.getInventoryData().giveItem(CommonEnvironment.this.simulation, unit, newItem, false);
+					final CAbilityInventory inventoryData = unit.getInventoryData();
+					if (inventoryData != null) {
+						inventoryData.giveItem(CommonEnvironment.this.simulation, unit, newItem, false);
+					}
 
 					return new HandleJassValue(itemType, newItem);
 				}
@@ -2660,7 +2663,10 @@ public class Jass2 {
 
 					final CItem newItem = CommonEnvironment.this.simulation.createItem(new War3ID(rawcode), unit.getX(),
 							unit.getY());
-					unit.getInventoryData().giveItem(CommonEnvironment.this.simulation, unit, newItem, slot, false);
+					final CAbilityInventory inventoryData = unit.getInventoryData();
+					if (inventoryData != null) {
+						inventoryData.giveItem(CommonEnvironment.this.simulation, unit, newItem, slot, false);
+					}
 
 					return new HandleJassValue(itemType, newItem);
 				}


### PR DESCRIPTION
Just run it with Reign of Chaos warchasers map and got a null pointer exception. With this check it loaded the map successfully.

Btw. this seems to be an actual bug in the Reforged Warchasers versions where all heroes except the BladeBerserker have no inventory anymore ....