### PR TITLE
Reincarnation

### DIFF
--- a/core/src/com/etheller/warsmash/viewer5/handlers/w3x/simulation/abilities/CAbility.java
+++ b/core/src/com/etheller/warsmash/viewer5/handlers/w3x/simulation/abilities/CAbility.java
@@ -16,6 +16,8 @@ public interface CAbility extends CAbilityView {
 
 	void onTick(CSimulation game, CUnit unit);
 
+	default void onBeforeDeath(CSimulation game, CUnit cUnit) {};
+
 	void onDeath(CSimulation game, CUnit cUnit);
 
 	/*

--- a/core/src/com/etheller/warsmash/viewer5/handlers/w3x/simulation/abilities/item/CAbilityItemReincarnation.java
+++ b/core/src/com/etheller/warsmash/viewer5/handlers/w3x/simulation/abilities/item/CAbilityItemReincarnation.java
@@ -1,0 +1,92 @@
+package com.etheller.warsmash.viewer5.handlers.w3x.simulation.abilities.item;
+
+import com.etheller.warsmash.util.War3ID;
+import com.etheller.warsmash.viewer5.handlers.w3x.simulation.CSimulation;
+import com.etheller.warsmash.viewer5.handlers.w3x.simulation.CUnit;
+import com.etheller.warsmash.viewer5.handlers.w3x.simulation.CWidget;
+import com.etheller.warsmash.viewer5.handlers.w3x.simulation.abilities.generic.AbstractGenericNoIconAbility;
+import com.etheller.warsmash.viewer5.handlers.w3x.simulation.abilities.skills.orc.chieftain.CAbilityReincarnation;
+import com.etheller.warsmash.viewer5.handlers.w3x.simulation.abilities.targeting.AbilityPointTarget;
+import com.etheller.warsmash.viewer5.handlers.w3x.simulation.behaviors.CBehavior;
+import com.etheller.warsmash.viewer5.handlers.w3x.simulation.util.AbilityActivationReceiver;
+import com.etheller.warsmash.viewer5.handlers.w3x.simulation.util.AbilityTargetCheckReceiver;
+
+public class CAbilityItemReincarnation extends AbstractGenericNoIconAbility {
+	private final int delay;
+	private final int restoredLife;
+	private final int restoredMana;
+
+	public CAbilityItemReincarnation(final int handleId, final War3ID alias, final int delay,
+			final int restoredLife, final int restoredMana) {
+		super(handleId, alias);
+		this.delay = delay;
+		this.restoredLife = restoredLife;
+		this.restoredMana = restoredMana;
+	}
+
+	@Override
+	public void onAdd(final CSimulation game, final CUnit unit) {
+	}
+
+	@Override
+	public void onRemove(final CSimulation game, final CUnit unit) {
+	}
+
+	@Override
+	public void onTick(final CSimulation game, final CUnit unit) {
+	}
+
+	@Override
+	public CBehavior begin(final CSimulation game, final CUnit caster, final int orderId, final CWidget target) {
+		return null;
+	}
+
+	@Override
+	public CBehavior begin(final CSimulation game, final CUnit caster, final int orderId,
+			final AbilityPointTarget point) {
+		return null;
+	}
+
+	@Override
+	public CBehavior beginNoTarget(final CSimulation game, final CUnit caster, final int orderId) {
+		return null;
+	}
+
+	@Override
+	public void checkCanTarget(final CSimulation game, final CUnit unit, final int orderId, final CWidget target,
+			final AbilityTargetCheckReceiver<CWidget> receiver) {
+		receiver.orderIdNotAccepted();
+	}
+
+	@Override
+	public void checkCanTarget(final CSimulation game, final CUnit unit, final int orderId,
+			final AbilityPointTarget target, final AbilityTargetCheckReceiver<AbilityPointTarget> receiver) {
+		receiver.orderIdNotAccepted();
+	}
+
+	@Override
+	public void checkCanTargetNoTarget(final CSimulation game, final CUnit unit, final int orderId,
+			final AbilityTargetCheckReceiver<Void> receiver) {
+		receiver.orderIdNotAccepted();
+	}
+
+	@Override
+	protected void innerCheckCanUse(final CSimulation game, final CUnit unit, final int orderId,
+			final AbilityActivationReceiver receiver) {
+		receiver.notAnActiveAbility();
+	}
+
+	@Override
+	public void onCancelFromQueue(final CSimulation game, final CUnit unit, final int orderId) {
+	}
+
+	@Override
+	public void onBeforeDeath(CSimulation game, CUnit cUnit) {
+		CAbilityReincarnation.heroDies(this, game, cUnit, restoredLife, restoredMana, delay);
+	}
+
+	@Override
+	public void onDeath(final CSimulation game, final CUnit cUnit) {
+	}
+
+}

--- a/core/src/com/etheller/warsmash/viewer5/handlers/w3x/simulation/abilities/skills/orc/chieftain/CAbilityReincarnation.java
+++ b/core/src/com/etheller/warsmash/viewer5/handlers/w3x/simulation/abilities/skills/orc/chieftain/CAbilityReincarnation.java
@@ -1,0 +1,92 @@
+package com.etheller.warsmash.viewer5.handlers.w3x.simulation.abilities.skills.orc.chieftain;
+
+import com.etheller.warsmash.units.manager.MutableObjectData.MutableGameObject;
+import com.etheller.warsmash.util.War3ID;
+import com.etheller.warsmash.viewer5.handlers.w3x.simulation.CSimulation;
+import com.etheller.warsmash.viewer5.handlers.w3x.simulation.CUnit;
+import com.etheller.warsmash.viewer5.handlers.w3x.simulation.abilities.generic.AbstractGenericAliasedAbility;
+import com.etheller.warsmash.viewer5.handlers.w3x.simulation.abilities.skills.CAbilityNoTargetSpellBase;
+import com.etheller.warsmash.viewer5.handlers.w3x.simulation.abilities.targeting.AbilityTarget;
+import com.etheller.warsmash.viewer5.handlers.w3x.simulation.abilities.types.definitions.impl.AbilityFields;
+import com.etheller.warsmash.viewer5.handlers.w3x.simulation.abilities.types.definitions.impl.AbstractCAbilityTypeDefinition;
+import com.etheller.warsmash.viewer5.handlers.w3x.simulation.timers.CTimer;
+import com.etheller.warsmash.viewer5.handlers.w3x.simulation.trigger.enumtypes.CEffectType;
+
+public class CAbilityReincarnation extends CAbilityNoTargetSpellBase {
+	private float delay;
+	private War3ID buffId;
+	private float castingTime;
+
+	public CAbilityReincarnation(final int handleId, final War3ID alias) {
+		super(handleId, alias);
+	}
+
+	@Override
+	public void populateData(final MutableGameObject worldEditorAbility, final int level) {
+		this.delay = worldEditorAbility.getFieldAsFloat(AbilityFields.REINCARNATION_DELAY_1,
+				level);
+		this.buffId = AbstractCAbilityTypeDefinition.getBuffId(worldEditorAbility, level);
+		this.castingTime = worldEditorAbility.getFieldAsFloat(AbilityFields.CASTING_TIME, level);
+	}
+
+	// TODO Which order ID?
+	@Override
+	public int getBaseOrderId() {
+		return 0;
+	}
+
+	@Override
+	public void onBeforeDeath(CSimulation game, CUnit cUnit) {
+		heroDies(this, game, cUnit, cUnit.getMaximumLife(), cUnit.getMaximumMana(), delay);
+	}
+
+	public static void heroDies(AbstractGenericAliasedAbility ability, CSimulation game, CUnit cUnit, float life, float mana, float delay) {
+		// prevent from dying
+		cUnit.setLife(game, life);
+
+		if (mana >= 0) {
+			cUnit.setMana(mana);
+		}
+
+		// hide from map
+		cUnit.setHidden(true);
+		cUnit.setInvulnerable(true);
+		cUnit.setPaused(true);
+
+		// effect
+		// TODO How to remove when hero is revived.
+		game.createSpellEffectOnUnit(cUnit, ability.getAlias(), CEffectType.CASTER);
+
+		final CTimer revivalTimer = new CTimer() {
+			@Override
+			public void onFire() {
+				cUnit.setHidden(false);
+				cUnit.setInvulnerable(false);
+				cUnit.setPaused(false);
+
+				// effect
+				game.createSpellEffectOnUnit(cUnit, ability.getAlias(), CEffectType.TARGET);
+			}
+		};
+		revivalTimer.setRepeats(false);
+		revivalTimer.setTimeoutTime(delay);
+		revivalTimer.start(game);
+	}
+
+	@Override
+	public boolean doEffect(final CSimulation simulation, final CUnit unit, final AbilityTarget target) {
+		return false;
+	}
+
+	public War3ID getBuffId() {
+		return this.buffId;
+	}
+
+	public float getCastingTime() {
+		return this.castingTime;
+	}
+
+	public void setBuffId(final War3ID buffId) {
+		this.buffId = buffId;
+	}
+}

--- a/core/src/com/etheller/warsmash/viewer5/handlers/w3x/simulation/abilities/types/definitions/impl/AbilityFields.java
+++ b/core/src/com/etheller/warsmash/viewer5/handlers/w3x/simulation/abilities/types/definitions/impl/AbilityFields.java
@@ -39,6 +39,8 @@ public interface AbilityFields {
 	public static final War3ID FERAL_SPIRIT_SUMMON_UNIT_TYPE_1 = War3ID.fromString("Osf1");
 	public static final War3ID FERAL_SPIRIT_SUMMON_UNIT_COUNT_1 = War3ID.fromString("Osf2");
 
+	public static final War3ID REINCARNATION_DELAY_1 = War3ID.fromString("Ore1");
+
 	public static final War3ID ITEM_EXPERIENCE_GAINED = War3ID.fromString("Ixpg");
 	public static final War3ID ITEM_LEVEL_GAINED = War3ID.fromString("Ilev");
 

--- a/core/src/com/etheller/warsmash/viewer5/handlers/w3x/simulation/abilities/types/definitions/impl/CAbilityTypeDefinitionItemReincarnation.java
+++ b/core/src/com/etheller/warsmash/viewer5/handlers/w3x/simulation/abilities/types/definitions/impl/CAbilityTypeDefinitionItemReincarnation.java
@@ -1,0 +1,38 @@
+package com.etheller.warsmash.viewer5.handlers.w3x.simulation.abilities.types.definitions.impl;
+
+import com.etheller.warsmash.units.manager.MutableObjectData.MutableGameObject;
+import com.etheller.warsmash.util.War3ID;
+import com.etheller.warsmash.viewer5.handlers.w3x.simulation.abilities.types.CAbilityType;
+import com.etheller.warsmash.viewer5.handlers.w3x.simulation.abilities.types.definitions.CAbilityTypeDefinition;
+import com.etheller.warsmash.viewer5.handlers.w3x.simulation.abilities.types.impl.CAbilityTypeItemReincarnation;
+import com.etheller.warsmash.viewer5.handlers.w3x.simulation.abilities.types.impl.CAbilityTypeItemReincarnationLevelData;
+import com.etheller.warsmash.viewer5.handlers.w3x.simulation.combat.CTargetType;
+
+import java.util.EnumSet;
+import java.util.List;
+
+public class CAbilityTypeDefinitionItemReincarnation
+		extends AbstractCAbilityTypeDefinition<CAbilityTypeItemReincarnationLevelData> implements CAbilityTypeDefinition {
+	protected static final War3ID DELAY = War3ID.fromString("Ircd");
+	protected static final War3ID RESTORED_LIFE = War3ID.fromString("irc2");
+	protected static final War3ID RESTORED_MANA = War3ID.fromString("irc3");
+
+	@Override
+	protected CAbilityTypeItemReincarnationLevelData createLevelData(final MutableGameObject abilityEditorData,
+			final int level) {
+		final String targetsAllowedAtLevelString = abilityEditorData.getFieldAsString(TARGETS_ALLOWED, level);
+		final int delay = abilityEditorData.getFieldAsInteger(DELAY, level);
+		final int restoredLife = abilityEditorData.getFieldAsInteger(RESTORED_LIFE, level);
+		final int restoredMana = abilityEditorData.getFieldAsInteger(RESTORED_MANA, level);
+		final EnumSet<CTargetType> targetsAllowedAtLevel = CTargetType.parseTargetTypeSet(targetsAllowedAtLevelString);
+		return new CAbilityTypeItemReincarnationLevelData(targetsAllowedAtLevel, delay, restoredLife,
+				restoredMana);
+	}
+
+	@Override
+	protected CAbilityType<?> innerCreateAbilityType(final War3ID alias, final MutableGameObject abilityEditorData,
+			final List<CAbilityTypeItemReincarnationLevelData> levelData) {
+		return new CAbilityTypeItemReincarnation(alias, abilityEditorData.getCode(), levelData);
+	}
+
+}

--- a/core/src/com/etheller/warsmash/viewer5/handlers/w3x/simulation/abilities/types/impl/CAbilityTypeItemReincarnation.java
+++ b/core/src/com/etheller/warsmash/viewer5/handlers/w3x/simulation/abilities/types/impl/CAbilityTypeItemReincarnation.java
@@ -1,0 +1,36 @@
+package com.etheller.warsmash.viewer5.handlers.w3x.simulation.abilities.types.impl;
+
+import com.etheller.warsmash.util.War3ID;
+import com.etheller.warsmash.viewer5.handlers.w3x.simulation.CSimulation;
+import com.etheller.warsmash.viewer5.handlers.w3x.simulation.abilities.CAbility;
+import com.etheller.warsmash.viewer5.handlers.w3x.simulation.abilities.generic.CLevelingAbility;
+import com.etheller.warsmash.viewer5.handlers.w3x.simulation.abilities.item.CAbilityItemReincarnation;
+import com.etheller.warsmash.viewer5.handlers.w3x.simulation.abilities.types.CAbilityType;
+import com.etheller.warsmash.viewer5.handlers.w3x.simulation.abilities.types.CAbilityTypeLevelData;
+
+import java.util.List;
+
+public class CAbilityTypeItemReincarnation extends CAbilityType<CAbilityTypeItemReincarnationLevelData> {
+
+	public CAbilityTypeItemReincarnation(final War3ID alias, final War3ID code,
+                                         final List<CAbilityTypeItemReincarnationLevelData> levelData) {
+		super(alias, code, levelData);
+	}
+
+	@Override
+	public CAbility createAbility(final int handleId) {
+		final CAbilityTypeItemReincarnationLevelData levelData = getLevelData(0);
+		return new CAbilityItemReincarnation(handleId, getAlias(), levelData.getDelay(), levelData.getRestoredLife(),
+				levelData.getRestoredMana());
+	}
+
+	@Override
+	public void setLevel(final CSimulation game, final CLevelingAbility existingAbility, final int level) {
+		final CAbilityTypeLevelData levelData = getLevelData(level - 1);
+		final CLevelingAbility heroAbility = (existingAbility);
+
+		// TODO ignores fields
+
+		heroAbility.setLevel(level);
+	}
+}

--- a/core/src/com/etheller/warsmash/viewer5/handlers/w3x/simulation/abilities/types/impl/CAbilityTypeItemReincarnationLevelData.java
+++ b/core/src/com/etheller/warsmash/viewer5/handlers/w3x/simulation/abilities/types/impl/CAbilityTypeItemReincarnationLevelData.java
@@ -1,0 +1,33 @@
+package com.etheller.warsmash.viewer5.handlers.w3x.simulation.abilities.types.impl;
+
+import com.etheller.warsmash.viewer5.handlers.w3x.simulation.abilities.types.CAbilityTypeLevelData;
+import com.etheller.warsmash.viewer5.handlers.w3x.simulation.combat.CTargetType;
+
+import java.util.EnumSet;
+
+public class CAbilityTypeItemReincarnationLevelData extends CAbilityTypeLevelData {
+
+	private final int delay;
+	private final int restoredLife;
+	private final int restoredMana;
+
+	public CAbilityTypeItemReincarnationLevelData(final EnumSet<CTargetType> targetsAllowed, final int delay,
+                                                  final int restoredLife, final int restoredMana) {
+		super(targetsAllowed);
+		this.delay = delay;
+		this.restoredLife = restoredLife;
+		this.restoredMana = restoredMana;
+	}
+
+	public int getDelay() {
+		return this.delay;
+	}
+
+	public int getRestoredLife() {
+		return this.restoredLife;
+	}
+
+	public int getRestoredMana() {
+		return this.restoredMana;
+	}
+}

--- a/core/src/com/etheller/warsmash/viewer5/handlers/w3x/simulation/data/CAbilityData.java
+++ b/core/src/com/etheller/warsmash/viewer5/handlers/w3x/simulation/data/CAbilityData.java
@@ -22,6 +22,7 @@ import com.etheller.warsmash.viewer5.handlers.w3x.simulation.abilities.nightelf.
 import com.etheller.warsmash.viewer5.handlers.w3x.simulation.abilities.skills.human.archmage.CAbilityBlizzard;
 import com.etheller.warsmash.viewer5.handlers.w3x.simulation.abilities.skills.human.archmage.CAbilitySummonWaterElemental;
 import com.etheller.warsmash.viewer5.handlers.w3x.simulation.abilities.skills.neutral.darkranger.CAbilityCharm;
+import com.etheller.warsmash.viewer5.handlers.w3x.simulation.abilities.skills.orc.chieftain.CAbilityReincarnation;
 import com.etheller.warsmash.viewer5.handlers.w3x.simulation.abilities.skills.orc.farseer.CAbilityFeralSpirit;
 import com.etheller.warsmash.viewer5.handlers.w3x.simulation.abilities.types.CAbilityType;
 import com.etheller.warsmash.viewer5.handlers.w3x.simulation.abilities.types.definitions.CAbilityTypeDefinition;
@@ -99,6 +100,8 @@ public class CAbilityData {
 		// ----Orc----
 		this.codeToAbilityTypeDefinition.put(War3ID.fromString("AOsf"),
 				new CAbilityTypeDefinitionSpellBase((handleId, alias) -> new CAbilityFeralSpirit(handleId, alias)));
+		this.codeToAbilityTypeDefinition.put(War3ID.fromString("AOre"),
+				new CAbilityTypeDefinitionSpellBase((handleId, alias) -> new CAbilityReincarnation(handleId, alias)));
 
 		// Burrow:
 		this.codeToAbilityTypeDefinition.put(War3ID.fromString("Abun"), new CAbilityTypeDefinitionCargoHoldBurrow());
@@ -155,6 +158,7 @@ public class CAbilityData {
 		this.codeToAbilityTypeDefinition.put(War3ID.fromString("AIma"), new CAbilityTypeDefinitionItemManaRegain());
 		this.codeToAbilityTypeDefinition.put(War3ID.fromString("AIat"), new CAbilityTypeDefinitionItemAttackBonus());
 		this.codeToAbilityTypeDefinition.put(War3ID.fromString("AIab"), new CAbilityTypeDefinitionItemStatBonus());
+		this.codeToAbilityTypeDefinition.put(War3ID.fromString("AIrc"), new CAbilityTypeDefinitionItemStatBonus());
 		this.codeToAbilityTypeDefinition.put(War3ID.fromString("AIim"),
 				new CAbilityTypeDefinitionItemPermanentStatGain());
 		this.codeToAbilityTypeDefinition.put(War3ID.fromString("AIsm"),


### PR DESCRIPTION
Hi again,
I am trying to implement Reincarnation now as hero ability as well as item ability.
My basic idea is to hide and pause the hero and make the hero invulnerable until he/she is revived.
To prevent actualy death I immediately set life above 0 and restore mana if necessary.

I have the following issues:
- Added onBeforeDeath since I do not know when to handle it before the unit dies.
- How to keep a target spell effect and remove it when the reincarnation actually happens.
- Not sure about the order ID.
- Should I check if it is actually a hero? What happens in original Warcraft?
- I immediately hide and pause the hero. I think in original Warcraft it shows some death animation but I think you cannot click on the hero icon anymore?

This whole pull request is unfinished but maybe you can give me some hints/feedback, so maybe in the future I can implement more abilities which are missing.