### PR TITLE
Bugfix to #32: Blight Growth can blight through unbuildable terrain

### DIFF
--- a/core/src/com/etheller/warsmash/viewer5/handlers/w3x/War3MapViewer.java
+++ b/core/src/com/etheller/warsmash/viewer5/handlers/w3x/War3MapViewer.java
@@ -87,6 +87,7 @@ import com.etheller.warsmash.viewer5.handlers.tga.TgaFile;
 import com.etheller.warsmash.viewer5.handlers.w3x.AnimationTokens.SecondaryTag;
 import com.etheller.warsmash.viewer5.handlers.w3x.SplatModel.SplatMover;
 import com.etheller.warsmash.viewer5.handlers.w3x.environment.BuildingShadow;
+import com.etheller.warsmash.viewer5.handlers.w3x.environment.GroundTexture;
 import com.etheller.warsmash.viewer5.handlers.w3x.environment.PathingGrid;
 import com.etheller.warsmash.viewer5.handlers.w3x.environment.PathingGrid.PathingType;
 import com.etheller.warsmash.viewer5.handlers.w3x.environment.PathingGrid.RemovablePathingMapInstance;
@@ -3093,6 +3094,14 @@ public class War3MapViewer extends AbstractMdxModelViewer {
 				final float dy = y - whichLocationY;
 				final float distSquared = (dx * dx) + (dy * dy);
 				if (distSquared <= rSquared) {
+					final RenderCorner corner = this.terrain.getCorner(x, y);
+					GroundTexture currentTex = this.terrain.groundTextures.get(corner.getGroundTexture());
+					if (corner != null && currentTex.isBuildable()) {
+						corner.setBlight(blighted);
+					} else {
+						continue;
+					}
+
 					for (float pathX = -64; pathX < 64; pathX += 32f) {
 						for (float pathY = -64; pathY < 64; pathY += 32f) {
 							final float blightX = x + pathX + 16;
@@ -3101,10 +3110,6 @@ public class War3MapViewer extends AbstractMdxModelViewer {
 								this.simulation.getPathingGrid().setBlighted(blightX, blightY, blighted);
 							}
 						}
-					}
-					final RenderCorner corner = this.terrain.getCorner(x, y);
-					if (corner != null) {
-						corner.setBlight(blighted);
 					}
 				}
 			}

--- a/core/src/com/etheller/warsmash/viewer5/handlers/w3x/environment/GroundTexture.java
+++ b/core/src/com/etheller/warsmash/viewer5/handlers/w3x/environment/GroundTexture.java
@@ -6,17 +6,28 @@ import java.nio.Buffer;
 
 import com.badlogic.gdx.graphics.GL30;
 import com.etheller.warsmash.datasources.DataSource;
+import com.etheller.warsmash.units.Element;
 import com.etheller.warsmash.util.ImageUtils;
 import com.etheller.warsmash.util.ImageUtils.AnyExtensionImage;
 
 public class GroundTexture {
 	public int id;
 	private int tileSize;
+	private boolean buildable;
 	public boolean extended;
 
-	public GroundTexture(final String path, final DataSource dataSource, final GL30 gl) throws IOException {
+	public GroundTexture(final String path, final Element terrainTileInfo, final DataSource dataSource, final GL30 gl) throws IOException {
+		if(terrainTileInfo != null) {
+			this.buildable = Integer.parseInt(terrainTileInfo.getField("buildable")) == 1;
+		} else {
+			this.buildable = true;
+		}
 		final AnyExtensionImage imageInfo = ImageUtils.getAnyExtensionImageFixRGB(dataSource, path, "ground texture");
 		loadImage(path, gl, imageInfo.getImageData(), imageInfo.isNeedsSRGBFix());
+	}
+
+	public boolean isBuildable() {
+		return buildable;
 	}
 
 	private void loadImage(final String path, final GL30 gl, final BufferedImage image, final boolean sRGBFix) {

--- a/core/src/com/etheller/warsmash/viewer5/handlers/w3x/environment/Terrain.java
+++ b/core/src/com/etheller/warsmash/viewer5/handlers/w3x/environment/Terrain.java
@@ -243,7 +243,7 @@ public class Terrain {
 			}
 			final String dir = terrainTileInfo.getField("dir");
 			final String file = terrainTileInfo.getField("file");
-			this.groundTextures.add(new GroundTexture(dir + "\\" + file + texturesExt, dataSource, Gdx.gl30));
+			this.groundTextures.add(new GroundTexture(dir + "\\" + file + texturesExt, terrainTileInfo, dataSource, Gdx.gl30));
 			this.groundTextureToId.put(groundTile.asStringValue(), this.groundTextures.size() - 1);
 		}
 
@@ -251,7 +251,7 @@ public class Terrain {
 
 		this.blightTextureIndex = this.groundTextures.size();
 		this.groundTextures.add(new GroundTexture(
-				tilesets.getField(Character.toString(tileset)).split(",")[1] + texturesExt, dataSource, Gdx.gl30));
+				tilesets.getField(Character.toString(tileset)).split(",")[1] + texturesExt, null, dataSource, Gdx.gl30));
 
 		// Cliff Textures
 		for (final War3ID cliffTile : w3eFile.getCliffTiles()) {


### PR DESCRIPTION
Bugfix is done by utilizing the buildable flag exist in the `TerrainArt/Terrain.slk` for `setBlight` to check.

Thanks to @Retera for pointing out the right direction.