### PR TITLE
UnitPortrait's animation plays synchronously with unitResponse audios.

### DIFF
--- a/core/src/com/etheller/warsmash/viewer5/handlers/mdx/MdxComplexInstance.java
+++ b/core/src/com/etheller/warsmash/viewer5/handlers/mdx/MdxComplexInstance.java
@@ -600,9 +600,9 @@ public class MdxComplexInstance extends ModelInstance {
 					this.animationCurrentDuration += frameTime;
 					this.sequenceLoopMode = SequenceLoopMode.ALWAYS_LOOP;
 				} else {
+					this.sequenceLoopMode = SequenceLoopMode.NEVER_LOOP;
 					SequenceUtils.randomPortraitSequence(this);
 					this.animationTargetDuration = 0;
-					return;
 				}
 			}
 

--- a/core/src/com/etheller/warsmash/viewer5/handlers/mdx/MdxComplexInstance.java
+++ b/core/src/com/etheller/warsmash/viewer5/handlers/mdx/MdxComplexInstance.java
@@ -74,7 +74,7 @@ public class MdxComplexInstance extends ModelInstance {
 	public Texture[] replaceableTextures_diffuse = new Texture[WarsmashConstants.REPLACEABLE_TEXTURE_LIMIT];
 	public Texture[] replaceableTextures_normal = new Texture[WarsmashConstants.REPLACEABLE_TEXTURE_LIMIT];
 	public Texture[] replaceableTextures_orm = new Texture[WarsmashConstants.REPLACEABLE_TEXTURE_LIMIT];
-	// If animationDuration is 0, it will play the whole animation.
+	// If animationTargetDuration is 0, it will play the whole animation.
 	public long animationTargetDuration = 0;
 	public long animationCurrentDuration = 0;
 	private float animationSpeed = 1.0f;
@@ -595,7 +595,6 @@ public class MdxComplexInstance extends ModelInstance {
 						this.vertexColor[3] - (integerFrameTime / (float) (interval[1] - interval[0])));
 			}
 
-			final long animEnd = interval[1] - 1;
 			if(this.animationTargetDuration != 0) {
 				if(this.animationCurrentDuration < this.animationTargetDuration) {
 					this.animationCurrentDuration += frameTime;
@@ -607,6 +606,7 @@ public class MdxComplexInstance extends ModelInstance {
 				}
 			}
 
+			final long animEnd = interval[1] - 1;
 			if (this.floatingFrame >= animEnd) {
 				boolean sequenceRestarted = false;
 				if ((this.sequenceLoopMode == SequenceLoopMode.ALWAYS_LOOP)

--- a/core/src/com/etheller/warsmash/viewer5/handlers/mdx/MdxComplexInstance.java
+++ b/core/src/com/etheller/warsmash/viewer5/handlers/mdx/MdxComplexInstance.java
@@ -27,6 +27,7 @@ import com.etheller.warsmash.viewer5.TextureMapper;
 import com.etheller.warsmash.viewer5.UpdatableObject;
 import com.etheller.warsmash.viewer5.gl.DataTexture;
 import com.etheller.warsmash.viewer5.handlers.w3x.DynamicShadowManager;
+import com.etheller.warsmash.viewer5.handlers.w3x.SequenceUtils;
 import com.hiveworkshop.rms.parsers.mdlx.MdlxGeoset;
 
 public class MdxComplexInstance extends ModelInstance {
@@ -73,6 +74,9 @@ public class MdxComplexInstance extends ModelInstance {
 	public Texture[] replaceableTextures_diffuse = new Texture[WarsmashConstants.REPLACEABLE_TEXTURE_LIMIT];
 	public Texture[] replaceableTextures_normal = new Texture[WarsmashConstants.REPLACEABLE_TEXTURE_LIMIT];
 	public Texture[] replaceableTextures_orm = new Texture[WarsmashConstants.REPLACEABLE_TEXTURE_LIMIT];
+	// If animationDuration is 0, it will play the whole animation.
+	public long animationTargetDuration = 0;
+	public long animationCurrentDuration = 0;
 	private float animationSpeed = 1.0f;
 	private float blendTime;
 	private float blendTimeRemaining;
@@ -592,6 +596,17 @@ public class MdxComplexInstance extends ModelInstance {
 			}
 
 			final long animEnd = interval[1] - 1;
+			if(this.animationTargetDuration != 0) {
+				if(this.animationCurrentDuration < this.animationTargetDuration) {
+					this.animationCurrentDuration += frameTime;
+					this.sequenceLoopMode = SequenceLoopMode.ALWAYS_LOOP;
+				} else {
+					SequenceUtils.randomPortraitSequence(this);
+					this.animationTargetDuration = 0;
+					return;
+				}
+			}
+
 			if (this.floatingFrame >= animEnd) {
 				boolean sequenceRestarted = false;
 				if ((this.sequenceLoopMode == SequenceLoopMode.ALWAYS_LOOP)

--- a/core/src/com/etheller/warsmash/viewer5/handlers/mdx/MdxComplexInstance.java
+++ b/core/src/com/etheller/warsmash/viewer5/handlers/mdx/MdxComplexInstance.java
@@ -27,7 +27,6 @@ import com.etheller.warsmash.viewer5.TextureMapper;
 import com.etheller.warsmash.viewer5.UpdatableObject;
 import com.etheller.warsmash.viewer5.gl.DataTexture;
 import com.etheller.warsmash.viewer5.handlers.w3x.DynamicShadowManager;
-import com.etheller.warsmash.viewer5.handlers.w3x.SequenceUtils;
 import com.hiveworkshop.rms.parsers.mdlx.MdlxGeoset;
 
 public class MdxComplexInstance extends ModelInstance {
@@ -74,9 +73,6 @@ public class MdxComplexInstance extends ModelInstance {
 	public Texture[] replaceableTextures_diffuse = new Texture[WarsmashConstants.REPLACEABLE_TEXTURE_LIMIT];
 	public Texture[] replaceableTextures_normal = new Texture[WarsmashConstants.REPLACEABLE_TEXTURE_LIMIT];
 	public Texture[] replaceableTextures_orm = new Texture[WarsmashConstants.REPLACEABLE_TEXTURE_LIMIT];
-	// If animationTargetDuration is 0, it will play the whole animation.
-	public long animationTargetDuration = 0;
-	public long animationCurrentDuration = 0;
 	private float animationSpeed = 1.0f;
 	private float blendTime;
 	private float blendTimeRemaining;
@@ -593,17 +589,6 @@ public class MdxComplexInstance extends ModelInstance {
 			if (this.additiveOverrideMeshMode) {
 				this.vertexColor[3] = Math.max(0,
 						this.vertexColor[3] - (integerFrameTime / (float) (interval[1] - interval[0])));
-			}
-
-			if(this.animationTargetDuration != 0) {
-				if(this.animationCurrentDuration < this.animationTargetDuration) {
-					this.animationCurrentDuration += frameTime;
-					this.sequenceLoopMode = SequenceLoopMode.ALWAYS_LOOP;
-				} else {
-					this.sequenceLoopMode = SequenceLoopMode.NEVER_LOOP;
-					SequenceUtils.randomPortraitSequence(this);
-					this.animationTargetDuration = 0;
-				}
 			}
 
 			final long animEnd = interval[1] - 1;

--- a/core/src/com/etheller/warsmash/viewer5/handlers/w3x/UnitSound.java
+++ b/core/src/com/etheller/warsmash/viewer5/handlers/w3x/UnitSound.java
@@ -149,6 +149,10 @@ public final class UnitSound {
 		return this.sounds.size();
 	}
 
+	public Sound getLastPlayedSound() {
+		return this.lastPlayedSound;
+	}
+
 	public void stop() {
 		for (final Sound sound : this.sounds) {
 			sound.stop();

--- a/core/src/com/etheller/warsmash/viewer5/handlers/w3x/ui/MeleeUI.java
+++ b/core/src/com/etheller/warsmash/viewer5/handlers/w3x/ui/MeleeUI.java
@@ -71,6 +71,7 @@ import com.etheller.warsmash.util.WarsmashConstants;
 import com.etheller.warsmash.viewer5.Bounds;
 import com.etheller.warsmash.viewer5.Scene;
 import com.etheller.warsmash.viewer5.ViewerTextureRenderable;
+import com.etheller.warsmash.viewer5.gl.Extensions;
 import com.etheller.warsmash.viewer5.handlers.mdx.Attachment;
 import com.etheller.warsmash.viewer5.handlers.mdx.MdxComplexInstance;
 import com.etheller.warsmash.viewer5.handlers.mdx.MdxModel;
@@ -1936,8 +1937,8 @@ public class MeleeUI implements CUnitStateListener, CommandButtonListener, Comma
 		}
 	}
 
-	public void portraitTalk() {
-		this.portrait.talk();
+	public void portraitTalk(UnitSound us) {
+		this.portrait.talk(us);
 	}
 
 	private final class AnyClickableUnitFilter implements CWidgetFilterFunction {
@@ -2452,13 +2453,19 @@ public class MeleeUI implements CUnitStateListener, CommandButtonListener, Comma
 			}
 		}
 
-		public void talk() {
+		public void talk(UnitSound us) {
 			// TODO we somehow called talk from null by clicking a unit right at the same
 			// time it died, so I do a null check here until I study that case further.
 			if (this.modelInstance != null) {
 				this.recycleSet.clear();
 				this.recycleSet.addAll(this.unit.getSecondaryAnimationTags());
 				this.recycleSet.add(SecondaryTag.TALK);
+				if(us != null) {
+					this.modelInstance.animationTargetDuration = (long)(1000 * Extensions.audio.getDuration(us.getLastPlayedSound()));
+				} else {
+					this.modelInstance.animationTargetDuration = 0;
+				}
+				this.modelInstance.animationCurrentDuration = 0;
 				SequenceUtils.randomSequence(this.modelInstance, PrimaryTag.PORTRAIT, this.recycleSet, true);
 			}
 		}
@@ -3604,7 +3611,7 @@ public class MeleeUI implements CUnitStateListener, CommandButtonListener, Comma
 									shiftDown);
 							if (getSelectedUnit().soundset.yes
 									.playUnitResponse(this.war3MapViewer.worldScene.audioContext, getSelectedUnit())) {
-								portraitTalk();
+								portraitTalk(getSelectedUnit().soundset.yes);
 							}
 							this.activeCommandUnit = null;
 							this.activeCommand = null;
@@ -3660,7 +3667,7 @@ public class MeleeUI implements CUnitStateListener, CommandButtonListener, Comma
 								}
 								if (getSelectedUnit().soundset.yes.playUnitResponse(
 										this.war3MapViewer.worldScene.audioContext, getSelectedUnit())) {
-									portraitTalk();
+									portraitTalk(getSelectedUnit().soundset.yes);
 								}
 								this.selectedSoundCount = 0;
 								if (this.activeCommand instanceof AbstractCAbilityBuild) {
@@ -3744,7 +3751,7 @@ public class MeleeUI implements CUnitStateListener, CommandButtonListener, Comma
 										: getSelectedUnit().soundset.yes;
 								if (yesSound.playUnitResponse(this.war3MapViewer.worldScene.audioContext,
 										getSelectedUnit())) {
-									portraitTalk();
+									portraitTalk(yesSound);
 								}
 								if (rallied) {
 									this.war3MapViewer.getUiSounds().getSound("RallyPointPlace")
@@ -3855,7 +3862,7 @@ public class MeleeUI implements CUnitStateListener, CommandButtonListener, Comma
 		final UnitSound yesSound = this.activeCommand instanceof CAbilityAttack ? getSelectedUnit().soundset.yesAttack
 				: getSelectedUnit().soundset.yes;
 		if (yesSound.playUnitResponse(this.war3MapViewer.worldScene.audioContext, getSelectedUnit())) {
-			portraitTalk();
+			portraitTalk(yesSound);
 		}
 		this.selectedSoundCount = 0;
 		if (this.activeCommand instanceof CAbilityRally) {
@@ -3903,7 +3910,7 @@ public class MeleeUI implements CUnitStateListener, CommandButtonListener, Comma
 		if (ordered) {
 			if (getSelectedUnit().soundset.yes.playUnitResponse(this.war3MapViewer.worldScene.audioContext,
 					getSelectedUnit())) {
-				portraitTalk();
+				portraitTalk(getSelectedUnit().soundset.yes);
 			}
 			if (rallied) {
 				this.war3MapViewer.getUiSounds().getSound("RallyPointPlace").play(this.uiScene.audioContext, 0, 0, 0);
@@ -3958,6 +3965,7 @@ public class MeleeUI implements CUnitStateListener, CommandButtonListener, Comma
 			if (selectionChanged) {
 				this.selectedSoundCount = 0;
 			}
+			UnitSound USAudio = null;
 			if ((unit.getSimulationUnit().getPlayerIndex() == this.war3MapViewer.getLocalPlayerIndex())
 					|| (unit.getSimulationUnit().getUnitType().getRace() == CUnitRace.CRITTERS)
 					|| ((unit.getSimulationUnit().getUnitType().getRace() == CUnitRace.OTHER)
@@ -3986,6 +3994,7 @@ public class MeleeUI implements CUnitStateListener, CommandButtonListener, Comma
 						if ((this.selectedSoundCount - 3) >= pissedSoundCount) {
 							this.selectedSoundCount = 0;
 						}
+						USAudio = ackSoundToPlay;
 						playedNewSound = true;
 					}
 				}
@@ -4013,7 +4022,7 @@ public class MeleeUI implements CUnitStateListener, CommandButtonListener, Comma
 				}
 			}
 			if (playedNewSound) {
-				portraitTalk();
+				portraitTalk(USAudio);
 			}
 		}
 		else {


### PR DESCRIPTION
UnitPortraits would play the talk animation as long as the unitResponse's audio being played, instead of playing the whole talk animation.