### PR TITLE
Prevent units from being highlighted behind UI by mouse.

### DIFF
--- a/core/src/com/etheller/warsmash/parsers/fdf/frames/AbstractUIFrame.java
+++ b/core/src/com/etheller/warsmash/parsers/fdf/frames/AbstractUIFrame.java
@@ -34,6 +34,21 @@ public abstract class AbstractUIFrame extends AbstractRenderableFrame implements
 		this.childFrames.remove(childFrame);
 	}
 
+	public boolean mouseOverUI(float screenX, float screenY) {
+		boolean res = false;
+		if(isVisible()) {
+			ListIterator<UIFrame> reverseIterator = this.childFrames.listIterator(this.childFrames.size());
+			while (reverseIterator.hasPrevious()) {
+				final AbstractRenderableFrame child = (AbstractRenderableFrame) reverseIterator.previous();
+				res = child.renderBounds.contains(screenX, screenY) && child.isVisible();
+				if(res) {
+					return res;
+				}
+			}
+		}
+		return res;
+	}
+
 	public AbstractUIFrame(final String name, final UIFrame parent) {
 		super(name, parent);
 	}

--- a/core/src/com/etheller/warsmash/parsers/fdf/frames/AbstractUIFrame.java
+++ b/core/src/com/etheller/warsmash/parsers/fdf/frames/AbstractUIFrame.java
@@ -34,7 +34,9 @@ public abstract class AbstractUIFrame extends AbstractRenderableFrame implements
 		this.childFrames.remove(childFrame);
 	}
 
-	// TODO: Separate in-game specific function from the UI class. 
+	/* TODO: Separate in-game specific function from the UI class. 
+		- Issue with unit highlight fluctuating remove due to hpBar and hover tips.
+	*/
 	public UIFrame mouseOverUI(float screenX, float screenY) {
 		UIFrame out = null;
 		if(isVisible()) {

--- a/core/src/com/etheller/warsmash/parsers/fdf/frames/AbstractUIFrame.java
+++ b/core/src/com/etheller/warsmash/parsers/fdf/frames/AbstractUIFrame.java
@@ -34,33 +34,8 @@ public abstract class AbstractUIFrame extends AbstractRenderableFrame implements
 		this.childFrames.remove(childFrame);
 	}
 
-	/* TODO: Separate in-game specific function from the UI class. 
-		- Issue with unit highlight fluctuating remove due to hpBar and hover tips.
-	*/
-	public UIFrame mouseOverUI(float screenX, float screenY) {
-		UIFrame out = null;
-		if(isVisible()) {
-			ListIterator<UIFrame> reverseIterator = this.childFrames.listIterator(this.childFrames.size());
-			while (reverseIterator.hasPrevious()) {
-				final UIFrame child = reverseIterator.previous();
-				boolean res = false;
-				// TODO: better implementation due to Backdrop being child class of AbstractUIFrame 
-				if(child instanceof AbstractUIFrame &&
-					!(child instanceof BackdropFrame)) {
-					out = ((AbstractUIFrame)child).mouseOverUI(screenX, screenY);
-					res = out != null;
-				} else {
-					final AbstractRenderableFrame renderFrame = (AbstractRenderableFrame) child;
-					res = renderFrame.renderBounds.contains(screenX, screenY) && renderFrame.isVisible();
-				}
-
-				if(res) {
-					out = child;
-					return child;
-				}
-			}
-		}
-		return out;
+	public ListIterator<UIFrame> getChildIterator() {
+		return this.childFrames.listIterator(this.childFrames.size());
 	}
 
 	public AbstractUIFrame(final String name, final UIFrame parent) {

--- a/core/src/com/etheller/warsmash/parsers/fdf/frames/AbstractUIFrame.java
+++ b/core/src/com/etheller/warsmash/parsers/fdf/frames/AbstractUIFrame.java
@@ -34,19 +34,31 @@ public abstract class AbstractUIFrame extends AbstractRenderableFrame implements
 		this.childFrames.remove(childFrame);
 	}
 
-	public boolean mouseOverUI(float screenX, float screenY) {
-		boolean res = false;
+	// TODO: Separate in-game specific function from the UI class. 
+	public UIFrame mouseOverUI(float screenX, float screenY) {
+		UIFrame out = null;
 		if(isVisible()) {
 			ListIterator<UIFrame> reverseIterator = this.childFrames.listIterator(this.childFrames.size());
 			while (reverseIterator.hasPrevious()) {
-				final AbstractRenderableFrame child = (AbstractRenderableFrame) reverseIterator.previous();
-				res = child.renderBounds.contains(screenX, screenY) && child.isVisible();
+				final UIFrame child = reverseIterator.previous();
+				boolean res = false;
+				// TODO: better implementation due to Backdrop being child class of AbstractUIFrame 
+				if(child instanceof AbstractUIFrame &&
+					!(child instanceof BackdropFrame)) {
+					out = ((AbstractUIFrame)child).mouseOverUI(screenX, screenY);
+					res = out != null;
+				} else {
+					final AbstractRenderableFrame renderFrame = (AbstractRenderableFrame) child;
+					res = renderFrame.renderBounds.contains(screenX, screenY) && renderFrame.isVisible();
+				}
+
 				if(res) {
-					return res;
+					out = child;
+					return child;
 				}
 			}
 		}
-		return res;
+		return out;
 	}
 
 	public AbstractUIFrame(final String name, final UIFrame parent) {

--- a/core/src/com/etheller/warsmash/viewer5/handlers/w3x/ui/MeleeUI.java
+++ b/core/src/com/etheller/warsmash/viewer5/handlers/w3x/ui/MeleeUI.java
@@ -11,6 +11,7 @@ import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.Locale;
 import java.util.Queue;
 import java.util.Set;
@@ -45,6 +46,7 @@ import com.etheller.warsmash.parsers.fdf.datamodel.AnchorDefinition;
 import com.etheller.warsmash.parsers.fdf.datamodel.FramePoint;
 import com.etheller.warsmash.parsers.fdf.datamodel.TextJustify;
 import com.etheller.warsmash.parsers.fdf.datamodel.Vector4Definition;
+import com.etheller.warsmash.parsers.fdf.frames.AbstractRenderableFrame;
 import com.etheller.warsmash.parsers.fdf.frames.AbstractUIFrame;
 import com.etheller.warsmash.parsers.fdf.frames.FilterModeTextureFrame;
 import com.etheller.warsmash.parsers.fdf.frames.GlueTextButtonFrame;
@@ -383,6 +385,8 @@ public class MeleeUI implements CUnitStateListener, CommandButtonListener, Comma
 	private int hpBarFrameIndex = 0;
 	private boolean allowDrag;
 	private int currentlyDraggingPointer = -1;
+	private String[] includeFrames;
+	private String[] ignoreFrames;
 	private final ShapeRenderer shapeRenderer = new ShapeRenderer();
 	private final List<MultiSelectUnitStateListener> multiSelectUnitStateListeners = new ArrayList<>();
 	private long lastUnitClickTime = 0;
@@ -1284,6 +1288,8 @@ public class MeleeUI implements CUnitStateListener, CommandButtonListener, Comma
 		if (WarsmashConstants.CATCH_CURSOR) {
 			Gdx.input.setCursorCatched(true);
 		}
+		this.includeFrames = new String[]{"EscMenuBackDrop", "ScriptDialog", "SmashHoverTip", "SmashHpBar"};
+		this.ignoreFrames = new String[]{"SmashHoverTip", "SmashHpBar"};
 
 		this.meleeUIMinimap = createMinimap(this.war3MapViewer);
 
@@ -1862,6 +1868,54 @@ public class MeleeUI implements CUnitStateListener, CommandButtonListener, Comma
 		}
 		this.hpBarFrameIndex++;
 		return simpleStatusBarFrame;
+	}
+
+	private UIFrame getHoveredFrame(AbstractUIFrame startFrame, float screenX, float screenY, String[] includeParent, String[] ignoreFrame) {
+		UIFrame outFrame = null;
+		if (startFrame.isVisible()) {
+			final ListIterator<UIFrame> curIterator = startFrame.getChildIterator();
+			while (curIterator.hasPrevious()) {
+				final UIFrame child = curIterator.previous();
+				boolean found = false;
+
+				if (child instanceof AbstractUIFrame) {
+					if (checkFrameInArray(child, includeParent)) {
+						AbstractRenderableFrame renderFrame = (AbstractRenderableFrame) child;
+						found = renderFrame.getRenderBounds().contains(screenX, screenY) && renderFrame.isVisible();	
+					} else {
+						outFrame = this.getHoveredFrame((AbstractUIFrame)child, screenX, screenY, includeParent, ignoreFrame);
+						found = outFrame != null;
+					}
+				} else {
+					AbstractRenderableFrame renderFrame = (AbstractRenderableFrame) child;
+					found = renderFrame.getRenderBounds().contains(screenX, screenY) &&
+							renderFrame.isVisible() &&
+							!checkFrameInArray(renderFrame, ignoreFrame);
+				}
+
+				if (found && !checkFrameInArray(child, ignoreFrame)) {
+					return child;
+				}
+			}
+		}
+		return outFrame;
+	}
+
+	private boolean checkFrameInArray(UIFrame frame, String[] targetFrames) {
+		if (targetFrames == null || frame == null) {
+			return false;
+		} else {
+			if (frame.getName() == null) {
+				return false;
+			}
+
+			for (int ind = 0; ind < targetFrames.length; ind++) {
+				if (frame.getName().startsWith(targetFrames[ind])) {
+					return true;
+				}
+			}
+			return false;
+		}
 	}
 
 	private void setCursorState(final MenuCursorState state, final Color color) {
@@ -3762,7 +3816,7 @@ public class MeleeUI implements CUnitStateListener, CommandButtonListener, Comma
 					}
 				}
 				else {
-					if (this.rootFrame.mouseOverUI(screenCoordsVector.x, screenCoordsVector.y) != null) {
+					if (this.getHoveredFrame((AbstractUIFrame)rootFrame, screenCoordsVector.x, screenCoordsVector.y, includeFrames, ignoreFrames) != null) {
 						return false;
 					}
 					
@@ -4217,7 +4271,7 @@ public class MeleeUI implements CUnitStateListener, CommandButtonListener, Comma
 				this.tooltipFrame.setVisible(false);
 			}
 		}
-		UIFrame hover = this.rootFrame.mouseOverUI(screenCoordsVector.x, screenCoordsVector.y);
+		UIFrame hover = this.getHoveredFrame( (AbstractUIFrame) this.rootFrame, screenCoordsVector.x, screenCoordsVector.y, includeFrames, ignoreFrames);
 		if (hover == null) {
 			final RenderWidget newMouseOverUnit = this.war3MapViewer.rayPickUnit(screenX, worldScreenY,
 					this.anyClickableUnitFilter);

--- a/core/src/com/etheller/warsmash/viewer5/handlers/w3x/ui/MeleeUI.java
+++ b/core/src/com/etheller/warsmash/viewer5/handlers/w3x/ui/MeleeUI.java
@@ -4213,8 +4213,8 @@ public class MeleeUI implements CUnitStateListener, CommandButtonListener, Comma
 				this.tooltipFrame.setVisible(false);
 			}
 		}
-		boolean hover = ((AbstractUIFrame)consoleUI).mouseOverUI(screenCoordsVector.x, screenCoordsVector.y);
-		if (!hover) {
+		UIFrame hover = this.rootFrame.mouseOverUI(screenCoordsVector.x, screenCoordsVector.y);
+		if (hover == null) {
 			final RenderWidget newMouseOverUnit = this.war3MapViewer.rayPickUnit(screenX, worldScreenY,
 					this.anyClickableUnitFilter);
 			if (newMouseOverUnit != this.mouseOverUnit) {

--- a/core/src/com/etheller/warsmash/viewer5/handlers/w3x/ui/MeleeUI.java
+++ b/core/src/com/etheller/warsmash/viewer5/handlers/w3x/ui/MeleeUI.java
@@ -1870,6 +1870,7 @@ public class MeleeUI implements CUnitStateListener, CommandButtonListener, Comma
 		return simpleStatusBarFrame;
 	}
 
+	// TODO: resourceBarGoldText and resourceBarLumberText cannot be identified due to resourceBarSupplyText overlapping the rest. 
 	private UIFrame getHoveredFrame(AbstractUIFrame startFrame, float screenX, float screenY, String[] includeParent, String[] ignoreFrame) {
 		UIFrame outFrame = null;
 		if (startFrame.isVisible()) {
@@ -1881,7 +1882,11 @@ public class MeleeUI implements CUnitStateListener, CommandButtonListener, Comma
 				if (child instanceof AbstractUIFrame) {
 					if (checkFrameInArray(child, includeParent)) {
 						AbstractRenderableFrame renderFrame = (AbstractRenderableFrame) child;
-						found = renderFrame.getRenderBounds().contains(screenX, screenY) && renderFrame.isVisible();	
+						found = renderFrame.getRenderBounds().contains(screenX, screenY) &&
+								renderFrame.isVisible();
+						if(found) {
+							outFrame = renderFrame;
+						}	
 					} else {
 						outFrame = this.getHoveredFrame((AbstractUIFrame)child, screenX, screenY, includeParent, ignoreFrame);
 						found = outFrame != null;
@@ -1889,12 +1894,14 @@ public class MeleeUI implements CUnitStateListener, CommandButtonListener, Comma
 				} else {
 					AbstractRenderableFrame renderFrame = (AbstractRenderableFrame) child;
 					found = renderFrame.getRenderBounds().contains(screenX, screenY) &&
-							renderFrame.isVisible() &&
-							!checkFrameInArray(renderFrame, ignoreFrame);
+							renderFrame.isVisible();
+					if(found) {
+						outFrame = renderFrame;
+					}
 				}
 
-				if (found && !checkFrameInArray(child, ignoreFrame)) {
-					return child;
+				if (outFrame != null && !checkFrameInArray(outFrame, ignoreFrame)) {
+					return outFrame;
 				}
 			}
 		}

--- a/core/src/com/etheller/warsmash/viewer5/handlers/w3x/ui/MeleeUI.java
+++ b/core/src/com/etheller/warsmash/viewer5/handlers/w3x/ui/MeleeUI.java
@@ -3762,6 +3762,10 @@ public class MeleeUI implements CUnitStateListener, CommandButtonListener, Comma
 					}
 				}
 				else {
+					if (this.rootFrame.mouseOverUI(screenCoordsVector.x, screenCoordsVector.y) != null) {
+						return false;
+					}
+					
 					this.war3MapViewer.getClickLocation(this.lastMouseClickLocation, screenX, (int) worldScreenY, true,
 							true);
 					this.lastMouseDragStart.set(this.lastMouseClickLocation);

--- a/core/src/com/etheller/warsmash/viewer5/handlers/w3x/ui/MeleeUI.java
+++ b/core/src/com/etheller/warsmash/viewer5/handlers/w3x/ui/MeleeUI.java
@@ -1288,7 +1288,7 @@ public class MeleeUI implements CUnitStateListener, CommandButtonListener, Comma
 		if (WarsmashConstants.CATCH_CURSOR) {
 			Gdx.input.setCursorCatched(true);
 		}
-		this.includeFrames = new String[]{"EscMenuBackDrop", "ScriptDialog", "SmashHoverTip", "SmashHpBar"};
+		this.includeFrames = new String[]{"EscMenuBackdrop", "ScriptDialog", "SmashHoverTip", "SmashHpBar"};
 		this.ignoreFrames = new String[]{"SmashHoverTip", "SmashHpBar"};
 
 		this.meleeUIMinimap = createMinimap(this.war3MapViewer);

--- a/core/src/com/etheller/warsmash/viewer5/handlers/w3x/ui/MeleeUI.java
+++ b/core/src/com/etheller/warsmash/viewer5/handlers/w3x/ui/MeleeUI.java
@@ -546,6 +546,9 @@ public class MeleeUI implements CUnitStateListener, CommandButtonListener, Comma
 		foodChanged();
 		this.resourceBarUpkeepText = (StringFrame) this.rootFrame.getFrameByName("ResourceBarUpkeepText", 0);
 		upkeepChanged();
+		this.resourceBarSupplyText.setWidth(this.resourceBarUpkeepText.getAssignedWidth());
+		this.resourceBarLumberText.setWidth(this.resourceBarUpkeepText.getAssignedWidth());
+		this.resourceBarGoldText.setWidth(this.resourceBarUpkeepText.getAssignedWidth());
 
 		final UIFrame upperButtonBar = this.rootFrame.createSimpleFrame("UpperButtonBarFrame", this.consoleUI, 0);
 		upperButtonBar.addSetPoint(new SetPoint(FramePoint.TOPLEFT, this.consoleUI, FramePoint.TOPLEFT, 0, 0));
@@ -1870,7 +1873,6 @@ public class MeleeUI implements CUnitStateListener, CommandButtonListener, Comma
 		return simpleStatusBarFrame;
 	}
 
-	// TODO: resourceBarGoldText and resourceBarLumberText cannot be identified due to resourceBarSupplyText overlapping the rest. 
 	private UIFrame getHoveredFrame(AbstractUIFrame startFrame, float screenX, float screenY, String[] includeParent, String[] ignoreFrame) {
 		UIFrame outFrame = null;
 		if (startFrame.isVisible()) {

--- a/core/src/com/etheller/warsmash/viewer5/handlers/w3x/ui/MeleeUI.java
+++ b/core/src/com/etheller/warsmash/viewer5/handlers/w3x/ui/MeleeUI.java
@@ -4213,7 +4213,8 @@ public class MeleeUI implements CUnitStateListener, CommandButtonListener, Comma
 				this.tooltipFrame.setVisible(false);
 			}
 		}
-		if (mousedUIFrame == null) {
+		boolean hover = ((AbstractUIFrame)consoleUI).mouseOverUI(screenCoordsVector.x, screenCoordsVector.y);
+		if (!hover) {
 			final RenderWidget newMouseOverUnit = this.war3MapViewer.rayPickUnit(screenX, worldScreenY,
 					this.anyClickableUnitFilter);
 			if (newMouseOverUnit != this.mouseOverUnit) {
@@ -4224,6 +4225,9 @@ public class MeleeUI implements CUnitStateListener, CommandButtonListener, Comma
 				}
 				this.mouseOverUnit = newMouseOverUnit;
 			}
+		} else {
+			this.war3MapViewer.clearUnitMouseOverHighlight();
+			this.mouseOverUnit = null;
 		}
 		return false;
 	}


### PR DESCRIPTION
This is a PR attempting to stop units behind UI from being highlighted/selected. It's partially able to stop highlighting units behind frames in `consoleUI` but `timeIndicator` frame and some dialogs (Game Menu, Victory, Exit, etc.) were able to highlight units. It is wonky right now so I would be aiming to do an elegant implementation of this.