### PR TITLE
Add GlobalBeginFunctionInstruction for 'globals'

### DIFF
--- a/jassparser/src/com/etheller/interpreter/ast/execution/instruction/GlobalBeginFunctionInstruction.java
+++ b/jassparser/src/com/etheller/interpreter/ast/execution/instruction/GlobalBeginFunctionInstruction.java
@@ -1,0 +1,21 @@
+package com.etheller.interpreter.ast.execution.instruction;
+
+import com.etheller.interpreter.ast.execution.JassThread;
+
+public class GlobalBeginFunctionInstruction extends BeginFunctionInstruction {
+    private boolean isDefined = false; // Prevent from multiple JassProgram::initialize calls to re-register the already defined global variables.
+
+    public GlobalBeginFunctionInstruction(final int lineNo, final String sourceFile, final String name) {
+        super(lineNo, sourceFile, name);
+    }
+
+    @Override
+    public void run(JassThread thread) {
+        super.run(thread);
+        if (isDefined) {
+            thread.instructionPtr = thread.stackFrame.returnAddressInstructionPtr;
+            return;
+        }
+        isDefined = true;
+    }
+}

--- a/jassparser/src/com/etheller/interpreter/ast/scope/GlobalScope.java
+++ b/jassparser/src/com/etheller/interpreter/ast/scope/GlobalScope.java
@@ -21,6 +21,7 @@ import com.etheller.interpreter.ast.execution.JassStackFrame;
 import com.etheller.interpreter.ast.execution.JassThread;
 import com.etheller.interpreter.ast.execution.instruction.BeginFunctionInstruction;
 import com.etheller.interpreter.ast.execution.instruction.BranchInstruction;
+import com.etheller.interpreter.ast.execution.instruction.GlobalBeginFunctionInstruction;
 import com.etheller.interpreter.ast.execution.instruction.InstructionAppendingJassStatementVisitor;
 import com.etheller.interpreter.ast.execution.instruction.JassInstruction;
 import com.etheller.interpreter.ast.execution.instruction.PushLiteralInstruction;
@@ -384,7 +385,7 @@ public final class GlobalScope {
 		else {
 			this.functionNameToInstructionPtr.put(INIT_GLOBALS_AUTOGEN_FXN_NAME, this.instructions.size());
 		}
-		this.instructions.add(new BeginFunctionInstruction(lineNo, sourceFile, INIT_GLOBALS_AUTOGEN_FXN_NAME));
+		this.instructions.add(new GlobalBeginFunctionInstruction(lineNo, sourceFile, INIT_GLOBALS_AUTOGEN_FXN_NAME));
 	}
 
 	public UserJassFunction getFunctionDefinitionByName(final String name) {


### PR DESCRIPTION
This is discussed in the Discord before but to iterate:

`JassProgram::initialize` (when called by `Jass2:doPreloadScript`) causes most of global variables to re-assign into their default value (null) after `Jass2:loadCommon` already initialized the global variables in `InitGlobals`. As I check, it seems the default registration of global variables (i.e the setters in `global` methods) is deeply integrated in the instruction list, making it tricky to simply decouple them off after initialization.

This is the one I have in mind to resolve the issue, if there are other methods in dealing with the assignments stored within the list, please let me know.