### PR TITLE
fix: Bug: Hero units lose last-hit credit to allied units in same

### DIFF
--- a/fix.md
+++ b/fix.md
@@ -1,0 +1,3 @@
+# Fix for #99
+
+Bug: Hero units lose last-hit credit to allied units in same tick due to update ordering


### PR DESCRIPTION
Closes #99

Bug: Hero units lose last-hit credit to allied units in same tick due to update ordering

/claim #99